### PR TITLE
Fix single-session conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # folders
-old_code/**
-specs/*
+old_code**
+specs**
+**pycache**
 
 # files
 *.zip
 notes.md
+*.csv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
+------------------------
 README - BIDS_conversion
 
-Code largely written by Maud Ottenheijm (DRCMR)
+Code by Maud Ottenheijm (DRCMR) - 2020 / 2021
+Heuristics setup is based on conversion package heudiconv: https://github.com/nipy/heudiconv
 
-
-
+------------------------
 This folder contains code for conversion of PARREC data to BIDS format (in nifti file format).
 This file gives a brief overview of the code makeup and how to use it.
 
@@ -24,13 +25,13 @@ Folder content:
 	- participants.tsv
 
 - add_params_afterconversion.py	: code to use for adding values to JSON sidecars after full conversion of a dataset. Called for single subject, adjust to include the desired values and filter criteria of file names
-	
+
 
 
 How to run conversion:
 
 
-Step 1: A .csv file with all log nrs should be in the same directory as main.py. This file should contain a first column with subject ID's, and subsequent columns with session ID's (in case of single-session data this is simply the subject ID again).
+Step 1: A .csv file with all log nrs should be in the same directory as main.py. This file should contain a column with 'old' subject ID's called **BIDSconvID**, a column with the BIDS subject id (fx. sub-lisa001) called **bidsID**, and subsequent columns with session ID's (in case of single-session data this is the ID of the raw data) called **ses-01**, **ses-02** etc. Other columns can be added, with appropriate column names. BIDSconverter expects a header row at the top of the file.
 
 
 Step 2: heuristics.py should be adjusted to include all new naming conventions and their filter criteria (use parameter information, not just name!).
@@ -38,25 +39,27 @@ Step 2: heuristics.py should be adjusted to include all new naming conventions a
 
 Step 3: run main.py as such
 
-python main.py [-h] -s sub_ID -n nr_of_sessions [-o output_directory]
+python main.py [-h] -s sub_ID [-o output_directory]
 				[-se session_ID [session_ID ...]] [-i input_directory]
-				[-l log_file] [-so] [-si study_ID]
+				[-l log_file] [--keep_sourcedata]
 
-s	[REQ]	- subject ID
-n	[REQ]	- nr of sessions to convert (if not all sessions should be converted, define -se)
-i	[OPT]	- input directory (root folder of converted dataset), default: input/
-si	[OPT]	- study ID, this will be appended to the subject number (fx. study ID = lisa, subject name = sub-lisa001)
-se	[OPT]	- session ID, can be a string or a list of strings (including one or more session ID's to be converted)
-l	[OPT]	- lognr csv (define as described in step 1), default: logfile.csv
+- -s	[REQ]	subject ID
+- -o	[OPT]	output directory for converted (BIDS) dataset, default: output/
+- -i	[OPT]	input directory (root folder of raw dataset), default: input/
+- -se	[OPT]	session ID, can be a string or a list of strings (including one or more session ID's to be converted)
+- -l	[OPT]	lognr csv (define as described in step 1), default: logfile.csv
+- --keep_sourcedata     Save source data - yes (True) or no (False), default: False
 
 
 Example 1 (from LISA study):
-python main.py -s FN011 -n 4 -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW/ -si lisa -l LISA_logno_2FU.csv
+python main.py -s FN011 -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW/ -l LISA_logno_2FU.csv
 
-This command converts all 4 sessions of one subject to the given output directory with study ID 'lisa'.
+This command converts all 4 sessions of one subject to the given output directory.
 
 Example 2:
-python main.py -s FN011 -n 2 -se [] -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW/ -si lisa
+python main.py -s FN011 -se ['someID', 'anotherID'] -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW --keep_sourcedata
+
+This command converts two specified sessions (by their original ID) of one subject to the output directory, while saving the intermittent converted files in [OUTPUTFOLDER]/[OLD_SUBNAME]]/, where OLD_SUBNAME here is FN011.
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This folder contains code for conversion of PARREC data to BIDS format (in nifti
 This file gives a brief overview of the code makeup and how to use it.
 
 
-###Folder content:
+### Folder content:
 
 - main.py			: contains main function, convert and rename functions, runs conversion of single subject to nifti, renames based on heuristics.py and writes logfiles
 - add_params.py		: called by main.py to add missing values to json sidecars
@@ -31,18 +31,18 @@ This file gives a brief overview of the code makeup and how to use it.
 
 
 
-###How to run conversion:
+### How to run conversion:
 
 
-######Step 1: 
+###### Step 1: 
 A .csv file with all log nrs should be in the same directory as main.py. This file should contain a column with 'old' subject ID's called **BIDSconvID**, a column with the BIDS subject id (fx. sub-lisa001) called **bidsID**, and subsequent columns with session ID's (in case of single-session data this is the ID of the raw data) called **ses-01**, **ses-02** etc. Other columns can be added, with appropriate column names. BIDSconverter expects a header row at the top of the file.
 
 
-######Step 2: 
+###### Step 2: 
 Heuristics.py should be adjusted to include all new naming conventions and their filter criteria (use parameter information, not just name!).
 
 
-######Step 3: 
+###### Step 3: 
 Run main.py as such
 
 python main.py [-h] -s sub_ID [-o output_directory]
@@ -59,19 +59,19 @@ python main.py [-h] -s sub_ID [-o output_directory]
 - --keep_sourcedata     Save source data - yes (True) or no (False), default: False
 
 
-######Example 1 (from LISA study):
+###### Example 1 (from LISA study):
 python main.py -s FN011 -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW/ -l LISA_logno_2FU.csv
 
 This command converts all 4 sessions of one subject to the given output directory.
 
-######Example 2:
+###### Example 2:
 python main.py -s FN011 -se ['someID', 'anotherID'] -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW --keep_sourcedata
 
 This command converts two specified sessions (by their original ID) of one subject to the output directory, while saving the intermittent converted files in [OUTPUTFOLDER]/[OLD_SUBNAME]]/, where OLD_SUBNAME here is FN011.
 
 
 
-###Error logs:
+### Error logs:
 
 For each subject, a conversion log file is kept to track which of the original data was successfully converted ([SUBNAME]_convertlog.tsv). Here the first column indicates successful conversion (0) or erroneous (1) results. Name of original file is included as well as the path.
 Also, a renaming file is kept to track which files are renamed to what and its success ([SUBNAME]_renamelog.tsv). Here the first column also indicates successful conversion (0) or erroneous (2) results. Old and new subject and session ID's are stored, as well as new file path and name.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 ------------------------
+
 README - BIDS_conversion
 
 Code by Maud Ottenheijm (DRCMR) - 2020 / 2021
+
 Heuristics setup is based on conversion package heudiconv: https://github.com/nipy/heudiconv
 
 ------------------------
+
 This folder contains code for conversion of PARREC data to BIDS format (in nifti file format).
 This file gives a brief overview of the code makeup and how to use it.
 
 
-Folder content:
+###Folder content:
 
 - main.py			: contains main function, convert and rename functions, runs conversion of single subject to nifti, renames based on heuristics.py and writes logfiles
 - add_params.py		: called by main.py to add missing values to json sidecars
@@ -28,19 +31,24 @@ Folder content:
 
 
 
-How to run conversion:
+###How to run conversion:
 
 
-Step 1: A .csv file with all log nrs should be in the same directory as main.py. This file should contain a column with 'old' subject ID's called **BIDSconvID**, a column with the BIDS subject id (fx. sub-lisa001) called **bidsID**, and subsequent columns with session ID's (in case of single-session data this is the ID of the raw data) called **ses-01**, **ses-02** etc. Other columns can be added, with appropriate column names. BIDSconverter expects a header row at the top of the file.
+######Step 1: 
+A .csv file with all log nrs should be in the same directory as main.py. This file should contain a column with 'old' subject ID's called **BIDSconvID**, a column with the BIDS subject id (fx. sub-lisa001) called **bidsID**, and subsequent columns with session ID's (in case of single-session data this is the ID of the raw data) called **ses-01**, **ses-02** etc. Other columns can be added, with appropriate column names. BIDSconverter expects a header row at the top of the file.
 
 
-Step 2: heuristics.py should be adjusted to include all new naming conventions and their filter criteria (use parameter information, not just name!).
+######Step 2: 
+Heuristics.py should be adjusted to include all new naming conventions and their filter criteria (use parameter information, not just name!).
 
 
-Step 3: run main.py as such
+######Step 3: 
+Run main.py as such
 
 python main.py [-h] -s sub_ID [-o output_directory]
+
 				[-se session_ID [session_ID ...]] [-i input_directory]
+
 				[-l log_file] [--keep_sourcedata]
 
 - -s	[REQ]	subject ID
@@ -51,19 +59,19 @@ python main.py [-h] -s sub_ID [-o output_directory]
 - --keep_sourcedata     Save source data - yes (True) or no (False), default: False
 
 
-Example 1 (from LISA study):
+######Example 1 (from LISA study):
 python main.py -s FN011 -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW/ -l LISA_logno_2FU.csv
 
 This command converts all 4 sessions of one subject to the given output directory.
 
-Example 2:
+######Example 2:
 python main.py -s FN011 -se ['someID', 'anotherID'] -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW --keep_sourcedata
 
 This command converts two specified sessions (by their original ID) of one subject to the output directory, while saving the intermittent converted files in [OUTPUTFOLDER]/[OLD_SUBNAME]]/, where OLD_SUBNAME here is FN011.
 
 
 
-Error logs:
+###Error logs:
 
 For each subject, a conversion log file is kept to track which of the original data was successfully converted ([SUBNAME]_convertlog.tsv). Here the first column indicates successful conversion (0) or erroneous (1) results. Name of original file is included as well as the path.
 Also, a renaming file is kept to track which files are renamed to what and its success ([SUBNAME]_renamelog.tsv). Here the first column also indicates successful conversion (0) or erroneous (2) results. Old and new subject and session ID's are stored, as well as new file path and name.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-------------------------
+# README - BIDS_conversion
 
-README - BIDS_conversion
-
-Code by Maud Ottenheijm (DRCMR) - 2020 / 2021
-
-Heuristics setup is based on conversion package heudiconv: https://github.com/nipy/heudiconv
+### Code by Maud Ottenheijm (DRCMR) - 2020 / 2021
+#### Heuristics setup is based on conversion package heudiconv: https://github.com/nipy/heudiconv
 
 ------------------------
 
@@ -34,18 +31,18 @@ This file gives a brief overview of the code makeup and how to use it.
 ### How to run conversion:
 
 
-###### Step 1: 
+#### Step 1: 
 A .csv file with all log nrs should be in the same directory as main.py. This file should contain a column with 'old' subject ID's called **BIDSconvID**, a column with the BIDS subject id (fx. sub-lisa001) called **bidsID**, and subsequent columns with session ID's (in case of single-session data this is the ID of the raw data) called **ses-01**, **ses-02** etc. Other columns can be added, with appropriate column names. BIDSconverter expects a header row at the top of the file.
 
 
-###### Step 2: 
+#### Step 2: 
 Heuristics.py should be adjusted to include all new naming conventions and their filter criteria (use parameter information, not just name!).
 
 
-###### Step 3: 
+#### Step 3: 
 Run main.py as such
 
-python main.py [-h] -s sub_ID [-o output_directory]
+				python main.py [-h] -s sub_ID [-o output_directory]
 
 				[-se session_ID [session_ID ...]] [-i input_directory]
 
@@ -59,12 +56,12 @@ python main.py [-h] -s sub_ID [-o output_directory]
 - --keep_sourcedata     Save source data - yes (True) or no (False), default: False
 
 
-###### Example 1 (from LISA study):
+#### Example 1 (from LISA study):
 python main.py -s FN011 -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW/ -l LISA_logno_2FU.csv
 
 This command converts all 4 sessions of one subject to the given output directory.
 
-###### Example 2:
+#### Example 2:
 python main.py -s FN011 -se ['someID', 'anotherID'] -o /mnt/projects/LISA/BIDS_LISA/ -i /mnt/xnat/LISA/arc001/{session}/SCANS/*/RAW --keep_sourcedata
 
 This command converts two specified sessions (by their original ID) of one subject to the output directory, while saving the intermittent converted files in [OUTPUTFOLDER]/[OLD_SUBNAME]]/, where OLD_SUBNAME here is FN011.

--- a/heuristics_LISA.py
+++ b/heuristics_LISA.py
@@ -25,27 +25,27 @@ def infotodict(seqinfo):
 	# Protocols for DRCMR - Copenhagen
 	# TODO Adjust keys for correct naming for each sequence included in study
 	
-	t1wmprage = create_key('sub-{s[subject]}/{s[session]}/anat/sub-{s[subject]}_{s[session]}_acq-{s[mod]}_T1w')
+	t1wmprage = create_key('{s[subject]}/{s[session]}/anat/{s[subject]}_{s[session]}_acq-{s[mod]}_T1w')
 	
-	t2w = create_key('sub-{s[subject]}/{s[session]}/anat/sub-{s[subject]}_{s[session]}_T2w')
+	t2w = create_key('{s[subject]}/{s[session]}/anat/{s[subject]}_{s[session]}_T2w')
 	
-	flair = create_key('sub-{s[subject]}/{s[session]}/anat/sub-{s[subject]}_{s[session]}_acq-{s[mod]}_FLAIR')
+	flair = create_key('{s[subject]}/{s[session]}/anat/{s[subject]}_{s[session]}_acq-{s[mod]}_FLAIR')
 	
-	flairME = create_key('sub-{s[subject]}/{s[session]}/swi/sub-{s[subject]}_{s[session]}_echo-{s[mod]}_GRE')
+	flairME = create_key('{s[subject]}/{s[session]}/swi/{s[subject]}_{s[session]}_echo-{s[mod]}_GRE')
 	
-	dwi = create_key('sub-{s[subject]}/{s[session]}/dwi/sub-{s[subject]}_{s[session]}_run-{s[run]}_dwi')
+	dwi = create_key('{s[subject]}/{s[session]}/dwi/{s[subject]}_{s[session]}_run-{s[run]}_dwi')
 	
-	dwi_ref = create_key('sub-{s[subject]}/{s[session]}/fmap/sub-{s[subject]}_{s[session]}_acq-dwi_dir-{s[mod]}_run-{s[run]}_epi')
+	dwi_ref = create_key('{s[subject]}/{s[session]}/fmap/{s[subject]}_{s[session]}_acq-dwi_dir-{s[mod]}_run-{s[run]}_epi')
 	
-	asl = create_key('sub-{s[subject]}/{s[session]}/perf/sub-{s[subject]}_{s[session]}_asl')
+	asl = create_key('{s[subject]}/{s[session]}/perf/{s[subject]}_{s[session]}_asl')
 	
-	asl_ref = create_key('sub-{s[subject]}/{s[session]}/perf/sub-{s[subject]}_{s[session]}_m0scan')
+	asl_ref = create_key('{s[subject]}/{s[session]}/perf/{s[subject]}_{s[session]}_m0scan')
 	
-	rest_PA = create_key('sub-{s[subject]}/{s[session]}/fmap/sub-{s[subject]}_{s[session]}_acq-bold_dir-{s[dir]}_run-{s[run]}_epi')
+	rest_PA = create_key('{s[subject]}/{s[session]}/fmap/{s[subject]}_{s[session]}_acq-bold_dir-{s[dir]}_run-{s[run]}_epi')
 	
-	rest = create_key('sub-{s[subject]}/{s[session]}/func/sub-{s[subject]}_{s[session]}_task-rest_run-{s[run]}_bold')
+	rest = create_key('{s[subject]}/{s[session]}/func/{s[subject]}_{s[session]}_task-rest_run-{s[run]}_bold')
 
-	other = create_key('sub-{s[subject]}/{s[session]}/other/sub-{s[subject]}_{s[session]}_run-{s[run]}_acq-{s[mod]}_other')
+	other = create_key('{s[subject]}/{s[session]}/other/{s[subject]}_{s[session]}_run-{s[run]}_acq-{s[mod]}_other')
 	
 	
 	# TODO Every protocol needs an entry here, NOTE: only included DRCMR protocols + 'other' (as check for leftover files)

--- a/logno.csv
+++ b/logno.csv
@@ -1,0 +1,1 @@
+BIDSconvID,bidsID,ses-01

--- a/main.py
+++ b/main.py
@@ -44,7 +44,10 @@ def arg_parser():
 	parser.add_argument('--keep_sourcedata', dest='keep_sd', action='store_true', 
 						help='Save source data - yes (True) or no (False), default: False')
 
-	parser.set_defaults(keep_sd=False)
+	parser.add_argument('--run_as_batch', dest='run_as_batch', action='store_true', 
+						help='Specify if code is run as batch - yes (True) or no (False), default: False')
+
+	parser.set_defaults(keep_sd=False, run_as_batch=False)
 
 	return parser
 
@@ -296,10 +299,10 @@ def main():
 	if isdir(join(args.output_dir, newsubname)):
 		print('NB! Converted data of this subject already (partly) exists. Be careful to not overwrite existing files.')
 		
-		# When used directly from command line, this block of code can be uncommented to ask for input when converting existing sub folder
+		# When used directly from command line, this block of code will ask for input when converting existing sub folder
 		# Does not work when submitting batch to cluster
 		
-		while args.cml = True:
+		while args.run_as_batch == False:
 			answer = input("Do you wish to continue anyway? y / n (possibly overwriting existing files): ")
 			
 			if answer.lower() == 'y':

--- a/main.py
+++ b/main.py
@@ -114,7 +114,7 @@ def convert_session(srow, oldses, newses, convert=True):
 						print('NB! Failed conversion: {} \nCheck .tsv in dataset/conversion_log/ for details.'.format(scanpath))
 						
 						# keep track of failed conversions
-						conversion = {'convs': 1, 'newsub': srow.bidsID, 'newses': newses, 'oldsub':args.subject_ID, 'oldses': oldses, 'ofn': scanpath, 'nfp': ''}
+						conversion = {'convs': 1, 'newsub': srow.bidsID.values[0], 'newses': newses, 'oldsub':args.subject_ID, 'oldses': oldses, 'ofn': scanpath, 'nfp': ''}
 						entry = '{convs}\t{newses}\t{oldsub}\t{oldses}\t{ofn}\t{nfp}'.format(**conversion)
 						failed.append(entry)
 					else:

--- a/main.py
+++ b/main.py
@@ -28,9 +28,9 @@ def arg_parser():
 	parser.add_argument('-s', '--subject_ID', type=str, required=True,
                     help='Subject ID - required', metavar='sub_ID')
 	
-	parser.add_argument('-n', '--nr_sessions', type=int,
-		                required=True, help='Number of sessions in study (and included in logfile). Unless session ID is given, all sessions are converted.',
-		                metavar='nr_of_sessions')
+	#parser.add_argument('-n', '--nr_sessions', type=int,
+	#	                required=True, help='Number of sessions in study (and included in logfile). Unless session ID is given, all sessions are converted.',
+	#	                metavar='nr_of_sessions')
 	
 	parser.add_argument('-o', '--output_dir', type=str,
 		                default='output/', help='Output directory - default: output/', metavar='output_directory')
@@ -44,9 +44,11 @@ def arg_parser():
 	
 	parser.add_argument('-l', '--logfile', type=str,
 		                default='include/logfile.csv', help='Full path to logfile with subject and session ID\'s. See documentation for required format.', metavar='log_file')
-		                
-	parser.add_argument('-so', '--keep_sourcedata', action='store_true',
-		                default=False, help='Save source data - yes (True) or no (False), default: False')
+	
+	parser.add_argument('--keep_sourcedata', dest='keep_sd', action='store_true', 
+						help='Save source data - yes (True) or no (False), default: False')
+
+	parser.set_defaults(keep_sd=False)
 
 	parser.add_argument('-si', '--study_ID', type=str,
 		                default='', help='Study ID, added to subject number in BIDS names (fx: study ID = lisa, BIDS name = \'sub-lisa001\') - string, default: none',
@@ -80,7 +82,9 @@ def parse_json(mypath):
 # Call dcm2niix for file conversion #
 #####################################
 
-def convert_session(subID, oldses, newses, convert=True):
+def convert_session(srow, oldses, newses, convert=True):
+	subID = srow.BIDSconvID.values[0]
+	
 	try:
 		inputdir = args.input_dir.format(session = oldses)
 		suboutdir = join(args.output_dir, subID, 'NII_ONLY')
@@ -88,7 +92,7 @@ def convert_session(subID, oldses, newses, convert=True):
 		
 		if not os.path.isdir(sesoutdir):
 			os.makedirs(sesoutdir)
-		
+
 		allScanPaths = []
 		scansup = glob(join(inputdir, '*.PAR'))
 		scanslow = glob(join(inputdir, '*.par'))
@@ -114,17 +118,18 @@ def convert_session(subID, oldses, newses, convert=True):
 						print('NB! Failed conversion: {} \nCheck .tsv in dataset/conversion_log/ for details.'.format(scanpath))
 						
 						# keep track of failed conversions
-						conversion = {'convs': 1, 'newsub': '', 'newses': newses, 'oldsub':args.subject_ID, 'oldses': oldses, 'ofn': scanpath, 'nfp': ''}
+						conversion = {'convs': 1, 'newsub': srow.bidsID, 'newses': newses, 'oldsub':args.subject_ID, 'oldses': oldses, 'ofn': scanpath, 'nfp': ''}
 						entry = '{convs}\t{newses}\t{oldsub}\t{oldses}\t{ofn}\t{nfp}'.format(**conversion)
 						failed.append(entry)
 					else:
 						file_found = glob(join(scanpath, '*.PAR')) + glob(join(scanpath, '*.par'))
 						w = [success.append(f) for f in file_found]
-						
-		return sesoutdir, success, failed
+		
+		return [sesoutdir, success, failed]
 	
 	except Exception as e:
 		print(e)
+		print("Error message in convert_session(). Check function inputs in main.py")
 		return 1
 
 
@@ -133,23 +138,13 @@ def convert_session(subID, oldses, newses, convert=True):
 # Get BIDS file name and location #
 ###################################
 
-def get_fn_sep(alsbs, colnames, conv_sessions, t):
+def get_fn_sep(srow, conv_sessions, nr_s):
 	if not isdir(join(args.output_dir, args.subject_ID)):
 		print('NB! Subject is not converted / not in .BIDS directory')
 		return 1
 	
-	# assign index of subject ID to i
-	ind = alsbs.loc[alsbs['subID']==args.subject_ID]
-	
-	try:
-		i = ind.index[0]
-	except Exception as e:
-		print(e)
-		print('NB! Sub ID is likely not found in logfile (BIDS_convert.py, line 135)')
-		return 1
-	
 	# get BIDS subject name, get conversion log file name
-	subname = '{}{:0{}}'.format(args.study_ID, i+1, t)
+	subname = srow.bidsID.values[0]
 	logfilename = '{}_renamelog.tsv'.format(subname)
 	logfilepath = join(args.output_dir, 'conversion_log')
 	
@@ -159,31 +154,21 @@ def get_fn_sep(alsbs, colnames, conv_sessions, t):
 	else:
 		mode = 'cp'
 
-	for j in range(args.nr_sessions):
-		ses = colnames[j+1]
+	for j, sesname in enumerate(conv_sessions):
 		
-		if args.nr_sessions > 1:
-			sesname = 'ses-0{}'.format(j+1)
-		else:
+		if nr_s == 1:
 			sesname = ''
 		
 		sespath = join(args.output_dir, args.subject_ID, 'NII_ONLY', sesname)
-		newpath = join(args.output_dir, 'sub-'+subname, sesname)
-		
-		if sesname not in conv_sessions:
-			continue
-		elif not isdir(sespath):
-			print('NB! Session is not converted / does not exist')
-			continue
+		newpath = join(args.output_dir, subname, sesname)
 		
 		if not isdir(newpath):
 			os.makedirs(newpath)
 			print('Made new dir: {}'.format(newpath))
 		
-		sesID = alsbs.loc[i, ses]
+		sesID = srow[conv_sessions[j]].values[0]
 		
 		ses_info, oldnames = parse_json(sespath)
-		allkeys = [s for s in ses_info]
 		
 		for key in ses_info:
 			for entry in ses_info[key]:
@@ -262,44 +247,41 @@ def main():
 		print('NB! Arguments are not passed correctly')
 		return 1
 	
-	colnames = ['subID']
-	cols = [0]
+	#colnames = ['subID']
+	#cols = [0]
 	
 	# get session names based on given nr of session in study
-	for i in range(args.nr_sessions):
-		colnames.append('ses-{:02}'.format(i+1))
-		cols.append(i+1)
+	#for i in range(args.nr_sessions):
+	#	colnames.append('ses-{:02}'.format(i+1))
+	#	cols.append(i+1)
+	print(args)
+
+	try:
+		if args.logfile.endswith('.csv'):
+			allsubs = pd.read_csv(args.logfile, header=0)
+		elif args.logfile.endswith('.tsv'):
+			allsubs = pd.read_csv(args.logfile, sep='\t', header=0)
+		
+		#allsubs = allsubs.astype(str)
+	except:
+		print('NB! Cannot load log file.\n Make sure the .csv logfile is in the same directory as this script, or pass the full path.')
+		return 1
+	
+	# get sub-specific info from csv file
+	srow = allsubs.loc[allsubs.BIDSconvID == args.subject_ID]
 	
 	try:
-		allsubs = pd.read_csv(args.logfile, sep='\t', names=colnames, usecols=cols)
-		allsubs.subID = allsubs.subID.astype(str)
-	except:
-		print('NB! Cannot load log file. Make sure the .csv logfile is in the same directory as this script.')
+		newsubname = srow.bidsID.values[0]
+	except IndexError:
+		print('NB! Subject not found in logfile.')
 		return 1
-	
-	ind = allsubs.loc[allsubs['subID']==args.subject_ID]
-	i = ind.index[0]
-	total = allsubs.shape[0]
-	
-	# If smarter way to check amount of subjects for numbering, insert here
-	if 1 <= total < 10:
-		t = 1
-	elif 10 <= total < 100:
-		t = 2
-	elif 100 <= total < 1000:
-		t = 3
-	elif 1000 <= total:
-		t = 4
-	
-	newsubname = 'sub-{}{:0{}}'.format(args.study_ID, i+1, t)
-	
+
 	# check output directories
-	if isdir(args.output_dir):
-		if not args.output_dir.endswith('/'):
-			args.output_dir += '/'
-	else:
+	if not isdir(args.output_dir):
 		print('NB! Output directory does not exist.')
 		return 1
+	elif not args.output_dir.endswith('/'):
+			args.output_dir += '/'
 	
 	# set log dir and file
 	logfilename = '{}_convertlog.tsv'.format(newsubname[4:])
@@ -314,7 +296,7 @@ def main():
 	# write logfile for conversion
 	if not isfile(join(logfilepath, logfilename_r)):
 		os.system('touch {lfn} && chmod 755 {lfn} && echo "renaming_success\tnewses\toldsub\toldses\toldfilename\tnewfilepath" > {lfn}'.format(lfn = join(logfilepath, logfilename_r)))
-		
+	
 	# write logfile for renaming
 	if not isfile(join(logfilepath, logfilename)):
 		os.system('touch {lfn} && chmod 755 {lfn} && echo "conversion_success\toldfilename\toldfilepath" > {lfn}'.format(lfn = join(logfilepath, logfilename)))
@@ -345,33 +327,45 @@ def main():
 		print('NB! This subject / session already partly exists, or is currently being converted. Use a different output directory or check existing data.')
 		return 1
 	
-	converted_sessions = 0
+	# make dict with sessions queued for conversion (either all sessions found in csv file, or given session IDs)
+	sq = {st:srow[st].values[0] for st in allsubs.columns if 'ses' in st}
+	
+	# total nr of sessions in study
+	nr_s = len(sq.keys())
+	
+	if args.session_ID != 'all':
+		sq = {k:v for k, v in sq.items() if v in args.session_ID}
+	
 	converted_sessions_names = []
 	
 	# convert specified nr of sessions (default = all)
-	for j in range(args.nr_sessions):
+	for newses, oldses in sq.items():
 		
-		if args.nr_sessions == 1:
+		# if study only has one session, don't include session layer in structure
+		if nr_s == 1:
 			newses = ''
-		else:
-			newses = colnames[j+1]
-		
-		oldses = allsubs.loc[i, colnames[j+1]]
-		
+
 		# Only convert if session exists
 		if type(oldses) == str:
 			# make code run session-specific
-			if args.session_ID != 'all':
-				if oldses not in args.session_ID:
-					continue
-				
-				if isdir(join(args.output_dir, newsubname, newses)):
-					print('NB! This session has already been converted.')
-					continue
+			#if args.session_ID != 'all':
+			#	
+			#	if oldses not in args.session_ID:
+			#		continue
+
+			if isdir(join(args.output_dir, newsubname, newses)):
+				print('NB! This session has already been converted.')
+				continue
 			
 			# convert files in ses directory (dcm2niix)
-			scandir, success_convs, failed_convs = convert_session(args.subject_ID, oldses, newses, True)
-			
+			rcs = convert_session(srow, oldses, newses, True)
+
+			if rcs == 1:
+				print("NB! conversion unsuccessful: subject {}, session {}".format(newsubname, newses))
+				scandir, success_convs, failed_convs = [[],[],[]]
+			else:
+				scandir, success_convs, failed_convs = rcs
+
 			for success_conv in success_convs:
 				suc = '0\t{}\t{}'.format(success_conv.split('/')[-1], '/'.join(success_conv.split('/')[:-1]))
 				os.system('echo "{suc}" >> {p}'.format(suc = suc, p = join(logfilepath, logfilename)))
@@ -390,23 +384,22 @@ def main():
 			# if no files in session dir, remove dir
 			elif not listdir(spath):
 				os.system('rm -r {}'.format(spath))
-				print('NB! Session resulted in zero output files. Check source data for potential missing conversions.')
+				print('NB! Session resulted in zero output files. Check source data for potential missing conversions (run again using --keep_sourcedata, check output folder for old subject ID).')
 			
 			# otherwise, count session as converted
 			else:
-				converted_sessions += 1
 				converted_sessions_names.append(newses)
 		
 		else:
-			print('Session doesn\'t exist.')
+			print('Session doesn\'t exist (no session name found in logfile).')
 	
 	# Sanity check
-	if converted_sessions == 0:
+	if len(converted_sessions_names) == 0:
 		print('NB! Zero sessions were converted. Conversion is stopped (no renaming done).')
 		return 1
 	
 	# rename converted data
-	renameRT = get_fn_sep(allsubs, colnames, converted_sessions_names, t)
+	renameRT = get_fn_sep(srow, converted_sessions_names, nr_s)
 	
 	if renameRT != 0:
 		print('NB! Renaming function returned non-zero. Check output for errors / warnings.')


### PR DESCRIPTION
Adjust the main function to handle a different logfile template.

BIDS naming of the subject is now done based on ID given in logfile instead of semi-hardcoding. This is to enable user to have non-congruent naming across logfile, and avoid double naming when logfile changes.

Further changes include the commandline arguments taken. No study ID needs to be given, or the nr of sessions in the study. This information is now taken from the logfile.

Lastly, a command-line argument is added to specify if code is run as a batch. Then no prompt will be given to avoid overwriting of intermittent files.